### PR TITLE
implement streaming model

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -6,6 +6,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/darling/mana/cmd"
+	"github.com/darling/mana/pkg/chat"
 	"github.com/darling/mana/pkg/llm"
 	_ "github.com/darling/mana/pkg/llm/providers/openrouter"
 	"github.com/darling/mana/pkg/tui"
@@ -16,6 +17,7 @@ func New(buildInfo version.BuildInfo) *cli.Command {
 	var (
 		openRouterAPIKey string
 		llmManager       *llm.Manager
+		chatService      chat.Service
 	)
 
 	return &cli.Command{
@@ -23,7 +25,7 @@ func New(buildInfo version.BuildInfo) *cli.Command {
 		Usage:   "The cutest LLM interface for your terminal",
 		Version: buildInfo.GetVersion(),
 		Action: func(ctx context.Context, c *cli.Command) error {
-			return tui.Run(llmManager)
+			return tui.Run(chatService)
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -46,6 +48,9 @@ func New(buildInfo version.BuildInfo) *cli.Command {
 					return ctx, err
 				}
 				llmManager = manager
+				// Wire chat service with in-memory store for now
+				store := chat.NewMemoryStore()
+				chatService = chat.NewDefaultService(store, llmManager)
 			}
 
 			return ctx, nil

--- a/pkg/chat/default_service.go
+++ b/pkg/chat/default_service.go
@@ -1,0 +1,117 @@
+package chat
+
+import (
+	"context"
+
+	"github.com/darling/mana/pkg/llm"
+)
+
+// DefaultService is a simple implementation that adapts llm.Manager and a Store.
+// It materializes user messages and assistant deltas into the Store.
+//
+// Streaming ergonomics:
+// - If the underlying provider supports streaming (future in llm.Manager), this will forward deltas.
+// - Otherwise, it will call Generate once and emit a single Done event with the full text.
+//
+// NOTE: In this initial commit, llm.Manager does not yet expose streaming. We wire the
+// non-streaming path and leave TODOs for streaming integration.
+
+type DefaultService struct {
+	store   Store
+	manager *llm.Manager
+}
+
+func NewDefaultService(store Store, manager *llm.Manager) *DefaultService {
+	return &DefaultService{store: store, manager: manager}
+}
+
+func (s *DefaultService) NewConversation(ctx context.Context, meta map[string]string) (ConversationID, error) {
+	return s.store.CreateConversation(ctx, meta)
+}
+
+func (s *DefaultService) AddUserMessage(ctx context.Context, conv ConversationID, content string, meta map[string]any) (MessageID, error) {
+	return s.store.AppendUserMessage(ctx, conv, content, meta)
+}
+
+func (s *DefaultService) StartAssistantStream(ctx context.Context, conv ConversationID, opts GenerateOptions) (<-chan StreamEvent, context.CancelFunc, error) {
+	// Create assistant placeholder message
+	assistantID, err := s.store.CreateAssistantMessage(ctx, conv, map[string]any{"model": opts.Model})
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	// Channel for events
+	events := make(chan StreamEvent, 16)
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		defer close(events)
+		// Load conversation to construct history for llm layer
+		msgs, err := s.store.GetConversation(ctx, conv)
+		if err != nil {
+			select {
+			case events <- StreamEvent{Conversation: conv, MessageID: assistantID, Err: err}:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		// Map chat.Message -> llm.Message history
+		llmHistory := make([]llm.Message, 0, len(msgs))
+		for _, m := range msgs {
+			llmHistory = append(llmHistory, llm.Message{Role: string(m.Role), Content: m.Content})
+		}
+
+		stream, err := s.manager.GenerateStream(ctx, llmHistory)
+		if err != nil {
+			select {
+			case events <- StreamEvent{Conversation: conv, MessageID: assistantID, Err: err}:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		for data := range stream {
+			if data.Err != nil {
+				// Surface error and stop
+				select {
+				case events <- StreamEvent{Conversation: conv, MessageID: assistantID, Err: data.Err}:
+				case <-ctx.Done():
+				}
+				return
+			}
+			if data.Delta != "" {
+				_ = s.store.AppendAssistantDelta(ctx, conv, assistantID, data.Delta)
+				select {
+				case events <- StreamEvent{Conversation: conv, MessageID: assistantID, Delta: data.Delta}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if data.Done {
+				_ = s.store.CompleteAssistantMessage(ctx, conv, assistantID, nil)
+				select {
+				case events <- StreamEvent{Conversation: conv, MessageID: assistantID, Done: true}:
+				case <-ctx.Done():
+				}
+				return
+			}
+		}
+		// If stream channel closes without Done, complete anyway
+		_ = s.store.CompleteAssistantMessage(ctx, conv, assistantID, nil)
+		select {
+		case events <- StreamEvent{Conversation: conv, MessageID: assistantID, Done: true}:
+		case <-ctx.Done():
+		}
+	}()
+
+	return events, cancel, nil
+}
+
+func (s *DefaultService) GetConversation(ctx context.Context, conv ConversationID) ([]Message, error) {
+	return s.store.GetConversation(ctx, conv)
+}
+
+func (s *DefaultService) List(ctx context.Context, limit int) ([]ConversationID, error) {
+	return s.store.ListConversations(ctx, limit)
+}

--- a/pkg/chat/doc.go
+++ b/pkg/chat/doc.go
@@ -1,0 +1,11 @@
+// Package chat defines domain types and interfaces for conversations
+// and streaming generation, decoupling UI from provider specifics.
+//
+// This layer sits above pkg/llm and below UIs. It is responsible for
+// mapping provider deltas into domain events, and coordinating persistence
+// via a Store.
+//
+// Short term: we will add an in-memory Store and a default Service
+// implementation that adapts pkg/llm.Manager, while keeping TODOs for
+// SQLite and richer features.
+package chat

--- a/pkg/chat/memory_store.go
+++ b/pkg/chat/memory_store.go
@@ -1,0 +1,111 @@
+package chat
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// memoryStore is a minimal in-memory Store implementation for short-term use.
+// It is safe for basic concurrent use via a RWMutex. It is not optimized.
+// TODO: Replace or complement with a SQLite-backed implementation.
+type memoryStore struct {
+	mu            sync.RWMutex
+	conversations map[ConversationID][]Message
+}
+
+// NewMemoryStore constructs an in-memory Store suitable for initial wiring/tests.
+func NewMemoryStore() Store {
+	return &memoryStore{conversations: make(map[ConversationID][]Message)}
+}
+
+func (s *memoryStore) CreateConversation(ctx context.Context, meta map[string]string) (ConversationID, error) {
+	id := ConversationID(time.Now().UTC().Format("20060102T150405.000000000"))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conversations[id] = nil
+	return id, nil
+}
+
+func (s *memoryStore) AppendUserMessage(ctx context.Context, conv ConversationID, content string, meta map[string]any) (MessageID, error) {
+	msgID := MessageID(time.Now().UTC().Format("20060102T150405.000000000"))
+	msg := Message{
+		ID:           msgID,
+		Conversation: conv,
+		Role:         RoleUser,
+		Content:      content,
+		CreatedAt:    time.Now().UTC(),
+		Metadata:     meta,
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conversations[conv] = append(s.conversations[conv], msg)
+	return msgID, nil
+}
+
+func (s *memoryStore) CreateAssistantMessage(ctx context.Context, conv ConversationID, meta map[string]any) (MessageID, error) {
+	msgID := MessageID(time.Now().UTC().Format("20060102T150405.000000000"))
+	msg := Message{
+		ID:           msgID,
+		Conversation: conv,
+		Role:         RoleAssistant,
+		Content:      "",
+		CreatedAt:    time.Now().UTC(),
+		Metadata:     meta,
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conversations[conv] = append(s.conversations[conv], msg)
+	return msgID, nil
+}
+
+func (s *memoryStore) AppendAssistantDelta(ctx context.Context, conv ConversationID, msg MessageID, delta string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	msgs := s.conversations[conv]
+	for i := range msgs {
+		if msgs[i].ID == msg {
+			msgs[i].Content += delta
+			break
+		}
+	}
+	s.conversations[conv] = msgs
+	return nil
+}
+
+func (s *memoryStore) CompleteAssistantMessage(ctx context.Context, conv ConversationID, msg MessageID, usage *Usage) error {
+	completed := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	msgs := s.conversations[conv]
+	for i := range msgs {
+		if msgs[i].ID == msg {
+			msgs[i].CompletedAt = &completed
+			break
+		}
+	}
+	s.conversations[conv] = msgs
+	return nil
+}
+
+func (s *memoryStore) ListConversations(ctx context.Context, limit int) ([]ConversationID, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]ConversationID, 0, len(s.conversations))
+	for id := range s.conversations {
+		ids = append(ids, id)
+	}
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}
+
+func (s *memoryStore) GetConversation(ctx context.Context, conv ConversationID) ([]Message, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	msgs := s.conversations[conv]
+	out := make([]Message, len(msgs))
+	copy(out, msgs)
+	return out, nil
+}

--- a/pkg/chat/service.go
+++ b/pkg/chat/service.go
@@ -1,0 +1,32 @@
+package chat
+
+import (
+	"context"
+)
+
+// Service is the domain-level API used by UIs to manage chats.
+// It coordinates with the provider layer and the Store.
+//
+// The Service is designed to be streaming-first. It exposes a StartAssistantStream
+// method that returns a channel of StreamEvent values.
+//
+// In the short term, this is an interface; an implementation will be added and wired later.
+// TODO: Implement a default Service that uses pkg/llm.Manager for providers and a Store.
+// TODO: Provide an in-memory Store implementation for initial integration tests.
+type Service interface {
+	// NewConversation creates a conversation with optional metadata and returns its ID.
+	NewConversation(ctx context.Context, meta map[string]string) (ConversationID, error)
+
+	// AddUserMessage appends a user message to the conversation.
+	AddUserMessage(ctx context.Context, conv ConversationID, content string, meta map[string]any) (MessageID, error)
+
+	// StartAssistantStream starts assistant generation for the given conversation.
+	// It returns a read-only channel of StreamEvent and a cancel function to terminate the stream.
+	StartAssistantStream(ctx context.Context, conv ConversationID, opts GenerateOptions) (<-chan StreamEvent, context.CancelFunc, error)
+
+	// GetConversation returns the materialized conversation messages.
+	GetConversation(ctx context.Context, conv ConversationID) ([]Message, error)
+
+	// List returns a subset of conversation IDs for navigation.
+	List(ctx context.Context, limit int) ([]ConversationID, error)
+}

--- a/pkg/chat/store.go
+++ b/pkg/chat/store.go
@@ -1,0 +1,19 @@
+package chat
+
+import "context"
+
+// Store is the persistence port for chat conversations and messages.
+// Implementations may be in-memory, SQLite, or remote.
+//
+// NOTE: For the short term, we will likely use an in-memory store.
+// TODO: Provide a SQLite implementation under pkg/store/sqlite using modernc.org/sqlite.
+// TODO: Consider WAL and batching for delta persistence efficiency.
+type Store interface {
+	CreateConversation(ctx context.Context, meta map[string]string) (ConversationID, error)
+	AppendUserMessage(ctx context.Context, conv ConversationID, content string, meta map[string]any) (MessageID, error)
+	CreateAssistantMessage(ctx context.Context, conv ConversationID, meta map[string]any) (MessageID, error)
+	AppendAssistantDelta(ctx context.Context, conv ConversationID, msg MessageID, delta string) error
+	CompleteAssistantMessage(ctx context.Context, conv ConversationID, msg MessageID, usage *Usage) error
+	ListConversations(ctx context.Context, limit int) ([]ConversationID, error)
+	GetConversation(ctx context.Context, conv ConversationID) ([]Message, error)
+}

--- a/pkg/chat/types.go
+++ b/pkg/chat/types.go
@@ -1,0 +1,62 @@
+package chat
+
+import (
+	"time"
+)
+
+// ConversationID uniquely identifies a conversation/thread.
+type ConversationID string
+
+// MessageID uniquely identifies a message within a conversation.
+type MessageID string
+
+// Role represents the author of a message.
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+// Usage represents token accounting reported by a provider.
+type Usage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}
+
+// Message is the domain representation of a chat message.
+type Message struct {
+	ID           MessageID
+	Conversation ConversationID
+	Role         Role
+	Content      string
+	Provider     string
+	CreatedAt    time.Time
+	CompletedAt  *time.Time
+	// Metadata can store provider-specific fields (e.g., tool calls, annotations).
+	Metadata map[string]any
+}
+
+// StreamEvent conveys incremental generation state from the assistant.
+// Exactly one of Delta/Done/Err should be set per event.
+type StreamEvent struct {
+	Conversation ConversationID
+	MessageID    MessageID
+	Delta        string
+	Usage        *Usage
+	Done         bool
+	Err          error
+}
+
+// GenerateOptions are optional controls for a generation.
+type GenerateOptions struct {
+	// Model override for this request only.
+	Model string
+	// SystemPrompt allows injecting/overriding a system message.
+	SystemPrompt string
+	// Temperature, MaxTokens etc. can be added as needed.
+	// TODO: add common sampling/limits here and map per provider in the service.
+}

--- a/pkg/llm/providers/openrouter/openrouter.go
+++ b/pkg/llm/providers/openrouter/openrouter.go
@@ -1,12 +1,14 @@
 package openrouter
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/darling/mana/pkg/llm"
 )
@@ -28,6 +30,7 @@ type ChatMessage struct {
 type ChatCompletionRequest struct {
 	Model    string        `json:"model"`
 	Messages []ChatMessage `json:"messages"`
+	Stream   bool          `json:"stream,omitempty"`
 }
 
 type ChatCompletionChoice struct {
@@ -145,6 +148,122 @@ func (p *Provider) Generate(ctx context.Context, history []llm.Message) (llm.Mes
 		Role:     choice.Message.Role,
 		Content:  choice.Message.Content,
 	}, nil
+}
+
+// streamChunk mirrors the structure of OpenAI-style streaming chunks used by OpenRouter.
+// Only the relevant subset is modeled here.
+type streamChunk struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Role    string `json:"role,omitempty"`
+			Content string `json:"content,omitempty"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+// Ensure Provider implements llm.StreamingProvider
+var _ llm.StreamingProvider = (*Provider)(nil)
+
+func (p *Provider) GenerateStream(ctx context.Context, history []llm.Message) (<-chan llm.StreamData, error) {
+	// Convert history
+	messages := make([]ChatMessage, len(history))
+	for i, msg := range history {
+		messages[i] = ChatMessage{Role: msg.Role, Content: msg.Content}
+	}
+
+	request := ChatCompletionRequest{Model: p.model, Messages: messages, Stream: true}
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://openrouter.ai/api/v1/chat/completions", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.key)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HTTP-Referer", "https://github.com/darling/mana")
+	req.Header.Set("X-Title", "Mana CLI")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	// We'll stream from resp.Body and close it when the stream ends.
+	ch := make(chan llm.StreamData, 32)
+
+	go func() {
+		defer close(ch)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			var errorResp ErrorResponse
+			if err := json.NewDecoder(resp.Body).Decode(&errorResp); err != nil {
+				ch <- llm.StreamData{Err: fmt.Errorf("API request failed with status %d", resp.StatusCode)}
+				return
+			}
+			ch <- llm.StreamData{Err: fmt.Errorf("API error (code %d): %s", errorResp.Code, errorResp.Message)}
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		// Increase buffer for large SSE lines
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			// Expect lines in form: "data: {...}" or "data: [DONE]"
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if payload == "[DONE]" {
+				ch <- llm.StreamData{Done: true}
+				return
+			}
+			var chunk streamChunk
+			if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+				ch <- llm.StreamData{Err: fmt.Errorf("failed to decode stream chunk: %w", err)}
+				return
+			}
+			if len(chunk.Choices) == 0 {
+				continue
+			}
+			delta := chunk.Choices[0].Delta.Content
+			if delta != "" {
+				select {
+				case ch <- llm.StreamData{Delta: delta}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if chunk.Choices[0].FinishReason != "" {
+				// Some providers signal finish via reason on last chunk.
+				ch <- llm.StreamData{Done: true}
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			ch <- llm.StreamData{Err: err}
+			return
+		}
+		// If the loop exits without [DONE], consider it done.
+		ch <- llm.StreamData{Done: true}
+	}()
+
+	return ch, nil
 }
 
 type modelsResponse struct {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -4,13 +4,13 @@ import (
 	"log"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
-	"github.com/darling/mana/pkg/llm"
+	"github.com/darling/mana/pkg/chat"
 
 	"github.com/darling/mana/pkg/tui/core"
 )
 
-func Run(manager *llm.Manager) error {
-	root := core.NewRootCmp(manager)
+func Run(service chat.Service) error {
+	root := core.NewRootCmp(service)
 
 	p := tea.NewProgram(
 		root,

--- a/pkg/tui/core/root.go
+++ b/pkg/tui/core/root.go
@@ -4,7 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/v2/key"
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss/v2"
-	"github.com/darling/mana/pkg/llm"
+	"github.com/darling/mana/pkg/chat"
 	"github.com/darling/mana/pkg/tui/core/components"
 	"github.com/darling/mana/pkg/tui/core/layout"
 )
@@ -23,12 +23,12 @@ type rootCmp struct {
 
 	width, height int
 
-	llmManager *llm.Manager
+	chatService chat.Service
 }
 
-func NewRootCmp(manager *llm.Manager) RootCmp {
+func NewRootCmp(service chat.Service) RootCmp {
 	sidebar := NewSidebarCmp()
-	main := NewMainCmp(manager)
+	main := NewMainCmp(service)
 	statusbar := NewStatusBarCmp("v0.1.0")
 
 	focusables := []layout.Focusable{sidebar.Clone(), main.Clone()}
@@ -42,7 +42,7 @@ func NewRootCmp(manager *llm.Manager) RootCmp {
 		keys:         DefaultKeyMap,
 		focusManager: fm,
 		layerManager: layout.NewLayerManager(),
-		llmManager:   manager,
+		chatService:  service,
 	}
 }
 

--- a/pkg/tui/core/style.go
+++ b/pkg/tui/core/style.go
@@ -27,4 +27,20 @@ var (
 			BorderBottom(true).
 			BorderForeground(subtle).
 			MarginBottom(1)
+
+	// Message styles
+	MessageBlock = lipgloss.NewStyle().
+			MarginBottom(1)
+
+	MessageLabelBase = lipgloss.NewStyle().
+				Bold(true)
+
+	MessageLabelUser = MessageLabelBase.
+				Foreground(lipgloss.Color("12")) // Bright Blue
+
+	MessageLabelAssistant = MessageLabelBase.
+				Foreground(special) // Green
+
+	MessageLabelSystem = MessageLabelBase.
+				Foreground(highlight) // Magenta
 )


### PR DESCRIPTION
I want to have streaming earlier than later and this requires 2 major changes:

- chat interface for the ui to talk to the llm in an abstracted way that's easier for the ui and llm
- refactor openrouter to stream from the https response, yay!
- setup streaming events for messages in progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces an interactive terminal chat with live, streaming responses.
  * Automatically creates a conversation and retains message history per session.
  * Allows canceling an in-progress response.
  * Displays partial output as it arrives and renders Markdown when available.
  * Activates when an OpenRouter API key is configured.

* **Style**
  * Improved message layout with clearer spacing and distinct labels for User, Assistant, and System messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->